### PR TITLE
style: Run goimports on everything

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ func main() {
 
 The library covers our usage, but might not be comprehensive of the API. So we always welcome contributions and improvements from the community. Before sending pull requests, make sure you've done the following:
 
-* Run `go fmt` on all updated .go files.
+* Run `goimports` on all updated .go files.
 * Document all exported structs and funcs.
 
 ## License

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,8 +1,6 @@
 package writeas
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestAuthentication(t *testing.T) {
 	dwac := NewDevClient()

--- a/post_test.go
+++ b/post_test.go
@@ -1,10 +1,9 @@
 package writeas
 
 import (
-	"testing"
-
 	"fmt"
 	"strings"
+	"testing"
 )
 
 func TestCreatePost(t *testing.T) {

--- a/user.go
+++ b/user.go
@@ -1,8 +1,6 @@
 package writeas
 
-import (
-	"time"
-)
+import "time"
 
 type (
 	// AuthUser represents a just-authenticated user. It contains information

--- a/writeas.go
+++ b/writeas.go
@@ -3,13 +3,14 @@ package writeas
 
 import (
 	"bytes"
-	"code.as/core/socks"
 	"encoding/json"
 	"fmt"
-	"github.com/writeas/impart"
 	"io"
 	"net/http"
 	"time"
+
+	"code.as/core/socks"
+	"github.com/writeas/impart"
 )
 
 const (


### PR DESCRIPTION
Similar to writeas/writeas-cli#22, this change runs goimports on all
files and changes the recommendation in the Contributing section to do
the same.