### PR TITLE
collection: Support collecting posts

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -29,6 +29,12 @@ type (
 		Alias string `json:"alias"`
 		Title string `json:"title"`
 	}
+
+	// DeleteCollectionParams holds the parameters required to delete a
+	// collection.
+	DeleteCollectionParams struct {
+		Alias string `json:"-"`
+	}
 )
 
 // CreateCollection creates a new collection, returning a user-friendly error
@@ -140,8 +146,8 @@ func (c *Client) GetUserCollections() (*[]Collection, error) {
 // anonymous.
 //
 // See https://developers.write.as/docs/api/#delete-a-collection.
-func (c *Client) DeleteCollection(alias string) error {
-	endpoint := "/collections/" + alias
+func (c *Client) DeleteCollection(p *DeleteCollectionParams) error {
+	endpoint := "/collections/" + p.Alias
 	env, err := c.delete(endpoint, nil /* data */)
 	if err != nil {
 		return err

--- a/collection.go
+++ b/collection.go
@@ -135,3 +135,27 @@ func (c *Client) GetUserCollections() (*[]Collection, error) {
 	}
 	return colls, nil
 }
+
+// DeleteCollection permanently deletes a collection and makes any posts on it
+// anonymous.
+//
+// See https://developers.write.as/docs/api/#delete-a-collection.
+func (c *Client) DeleteCollection(alias string) error {
+	endpoint := "/collections/" + alias
+	env, err := c.delete(endpoint, nil /* data */)
+	if err != nil {
+		return err
+	}
+
+	status := env.Code
+	switch status {
+	case http.StatusNoContent:
+		return nil
+	case http.StatusUnauthorized:
+		return fmt.Errorf("Not authenticated.")
+	case http.StatusBadRequest:
+		return fmt.Errorf("Bad request: %s", env.ErrorMessage)
+	default:
+		return fmt.Errorf("Problem deleting collection: %d. %s\n", status, env.ErrorMessage)
+	}
+}

--- a/collection_test.go
+++ b/collection_test.go
@@ -71,7 +71,8 @@ func TestCreateAndDeleteCollection(t *testing.T) {
 		t.Fatalf("Unable to create collection %q: %v", alias, err)
 	}
 
-	if err := wac.DeleteCollection(c.Alias); err != nil {
+	p := &DeleteCollectionParams{Alias: c.Alias}
+	if err := wac.DeleteCollection(p); err != nil {
 		t.Fatalf("Unable to delete collection %q: %v", alias, err)
 	}
 }
@@ -81,7 +82,8 @@ func TestDeleteCollectionUnauthenticated(t *testing.T) {
 
 	now := time.Now().Unix()
 	alias := fmt.Sprintf("test-collection-does-not-exist-%v", now)
-	err := wac.DeleteCollection(alias)
+	p := &DeleteCollectionParams{Alias: alias}
+	err := wac.DeleteCollection(p)
 	if err == nil {
 		t.Fatalf("Should not be able to delete collection %q unauthenticated.", alias)
 	}

--- a/collection_test.go
+++ b/collection_test.go
@@ -2,6 +2,7 @@ package writeas
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -102,4 +103,60 @@ func ExampleClient_GetCollection() {
 	}
 	fmt.Printf("%s", coll.Title)
 	// Output: write.as
+}
+
+func TestCollectPostsAnonymous(t *testing.T) {
+	// Create a post anonymously.
+	wac := NewDevClient()
+	p, err := wac.CreatePost(&PostParams{
+		Title:   "Title!",
+		Content: "This is a post.",
+		Font:    "sans",
+	})
+	if err != nil {
+		t.Errorf("Post create failed: %v", err)
+		return
+	}
+	t.Logf("Post created: %+v", p)
+
+	// Log in.
+	if _, err := wac.LogIn("demo", "demo"); err != nil {
+		t.Fatalf("Unable to log in: %v", err)
+	}
+	defer wac.LogOut()
+
+	now := time.Now().Unix()
+	alias := fmt.Sprintf("test-collection-%v", now)
+
+	// Create a collection.
+	_, err = wac.CreateCollection(&CollectionParams{
+		Alias: alias,
+		Title: fmt.Sprintf("Test Collection %v", now),
+	})
+	if err != nil {
+		t.Fatalf("Unable to create collection %q: %v", alias, err)
+	}
+	defer wac.DeleteCollection(&DeleteCollectionParams{Alias: alias})
+
+	// Move the anonymous post to this collection.
+	res, err := wac.CollectPosts(&CollectPostParams{
+		Alias: alias,
+		Posts: []*CollectPost{
+			{
+				ID:    p.ID,
+				Token: p.Token,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Could not collect post %q: %v", p.ID, err)
+	}
+
+	for _, cr := range res {
+		if cr.Code != http.StatusOK {
+			t.Errorf("Failed to move post: %v", cr.ErrorMessage)
+		} else {
+			t.Logf("Moved post %q", cr.Post.ID)
+		}
+	}
 }

--- a/collection_test.go
+++ b/collection_test.go
@@ -2,7 +2,9 @@ package writeas
 
 import (
 	"fmt"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestGetCollection(t *testing.T) {
@@ -48,6 +50,44 @@ func TestGetUserCollections(t *testing.T) {
 		if len(*res) == 0 {
 			t.Errorf("No collections returned!")
 		}
+	}
+}
+
+func TestCreateAndDeleteCollection(t *testing.T) {
+	wac := NewDevClient()
+	_, err := wac.LogIn("demo", "demo")
+	if err != nil {
+		t.Fatalf("Unable to log in: %v", err)
+	}
+	defer wac.LogOut()
+
+	now := time.Now().Unix()
+	alias := fmt.Sprintf("test-collection-%v", now)
+	c, err := wac.CreateCollection(&CollectionParams{
+		Alias: alias,
+		Title: fmt.Sprintf("Test Collection %v", now),
+	})
+	if err != nil {
+		t.Fatalf("Unable to create collection %q: %v", alias, err)
+	}
+
+	if err := wac.DeleteCollection(c.Alias); err != nil {
+		t.Fatalf("Unable to delete collection %q: %v", alias, err)
+	}
+}
+
+func TestDeleteCollectionUnauthenticated(t *testing.T) {
+	wac := NewDevClient()
+
+	now := time.Now().Unix()
+	alias := fmt.Sprintf("test-collection-does-not-exist-%v", now)
+	err := wac.DeleteCollection(alias)
+	if err == nil {
+		t.Fatalf("Should not be able to delete collection %q unauthenticated.", alias)
+	}
+
+	if !strings.Contains(err.Error(), "Not authenticated") {
+		t.Fatalf("Error message should be more informative: %v", err)
 	}
 }
 


### PR DESCRIPTION
Note: This PR includes changes from #13 because the change being
proposed here relies on functionality added in #13. The change itself
can be reviewed in its own commit. The commit message for it is
repeated below.

---

This adds support for moving posts to a collection. This change relies
on #13 so that we can create and delete collections during tests.

Couple notes:

- CollectPosts accepts a single struct rather than an alias and a list
  of structs. This makes it easy to add new optional parameters in the
  future.

- We're passing `[]*CollectPost` around rather than `*[]CollectPost`
  which is done in some of the existing APIs. The reasoning for this is

  - Idiomatically, slices are passed by-value (`[]foo`) rather than
    by-pointer (`*[]foo`) because slices are already reference types.
    Plus they're really cheap to copy since they're just a triple:
    pointer, length, and capacity ([related blog post][1]). We need
    pointers to slices only when we're trying to modify the original
    slice reference and don't have the ability to return a slice, like
    with `json.Unmarshal` (see also [this post][2]).

  - If we're trying to reduce copying, `[]*foo` is better than `[]foo`
    because otherwise `foo` will be copied when manipulating or
    accessing entries in the slice (like ranging over it).

  Existing APIs were left as-is to avoid breaking them. I can switch to
  `*[]CollectPost` if you'd prefer that but `[]*CollectPost` is more
  idiomatic.

[1]: https://blog.golang.org/go-slices-usage-and-internals#TOC_4.
[2]: https://blog.golang.org/slices#TOC_5.

Resolves #4.