### PR TITLE
Remove unnecessary indirection

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -21,7 +21,7 @@ type (
 
 		TotalPosts int `json:"total_posts"`
 
-		Posts *[]Post `json:"posts,omitempty"`
+		Posts []Post `json:"posts,omitempty"`
 	}
 
 	// CollectionParams holds values for creating a collection.
@@ -91,7 +91,7 @@ func (c *Client) GetCollection(alias string) (*Collection, error) {
 // GetCollectionPosts retrieves a collection's posts, returning the Posts
 // and any error (in user-friendly form) that occurs. See
 // https://developers.write.as/docs/api/#retrieve-collection-posts
-func (c *Client) GetCollectionPosts(alias string) (*[]Post, error) {
+func (c *Client) GetCollectionPosts(alias string) ([]Post, error) {
 	coll := &Collection{}
 	env, err := c.get(fmt.Sprintf("/collections/%s/posts", alias), coll)
 	if err != nil {
@@ -139,17 +139,19 @@ func (c *Client) GetCollectionPost(alias, slug string) (*Post, error) {
 
 // GetUserCollections retrieves the authenticated user's collections.
 // See https://developers.write.as/docs/api/#retrieve-user-39-s-collections
-func (c *Client) GetUserCollections() (*[]Collection, error) {
-	colls := &[]Collection{}
-	env, err := c.get("/me/collections", colls)
+func (c *Client) GetUserCollections() ([]Collection, error) {
+	colls := []Collection{}
+	env, err := c.get("/me/collections", &colls)
 	if err != nil {
 		return nil, err
 	}
 
 	var ok bool
-	if colls, ok = env.Data.(*[]Collection); !ok {
-		return nil, fmt.Errorf("Wrong data returned from API.")
+	collsNew, ok := env.Data.(*[]Collection)
+	if !ok {
+		return nil, fmt.Errorf("Wrong data returned from API. '%+v'", env)
 	}
+	colls = *collsNew
 	status := env.Code
 
 	if status != http.StatusOK {

--- a/collection_test.go
+++ b/collection_test.go
@@ -28,10 +28,10 @@ func TestGetCollectionPosts(t *testing.T) {
 		if err != nil {
 			t.Errorf("Unexpected fetch results: %+v, err: %v\n", res, err)
 		}
-		if len(*res) == 0 {
+		if len(res) == 0 {
 			t.Error("Expected at least on post in collection")
 		}
-		posts = *res
+		posts = res
 	})
 	t.Run("Get one post from collection", func(t *testing.T) {
 		res, err := dwac.GetCollectionPost("tester", posts[0].Slug)
@@ -62,7 +62,7 @@ func TestGetUserCollections(t *testing.T) {
 		t.Errorf("Unexpected fetch results: %+v, err: %v\n", res, err)
 	} else {
 		t.Logf("User collections: %+v", res)
-		if len(*res) == 0 {
+		if len(res) == 0 {
 			t.Errorf("No collections returned!")
 		}
 	}

--- a/post.go
+++ b/post.go
@@ -210,17 +210,19 @@ func (c *Client) deletePost(collection, identifier, token string) error {
 
 // ClaimPosts associates anonymous posts with a user / account.
 // https://developers.write.as/docs/api/#claim-posts.
-func (c *Client) ClaimPosts(sp *[]OwnedPostParams) (*[]ClaimPostResult, error) {
-	p := &[]ClaimPostResult{}
-	env, err := c.post("/posts/claim", sp, p)
+func (c *Client) ClaimPosts(sp []OwnedPostParams) ([]ClaimPostResult, error) {
+	p := []ClaimPostResult{}
+	env, err := c.post("/posts/claim", sp, &p)
 	if err != nil {
 		return nil, err
 	}
 
 	var ok bool
-	if p, ok = env.Data.(*[]ClaimPostResult); !ok {
+	newP, ok := env.Data.(*[]ClaimPostResult)
+	if !ok {
 		return nil, fmt.Errorf("Wrong data returned from API.")
 	}
+	p = *newP
 
 	status := env.Code
 	if status == http.StatusOK {
@@ -237,17 +239,19 @@ func (c *Client) ClaimPosts(sp *[]OwnedPostParams) (*[]ClaimPostResult, error) {
 
 // GetUserPosts retrieves the authenticated user's posts.
 // See https://developers.write.as/docs/api/#retrieve-user-39-s-posts
-func (c *Client) GetUserPosts() (*[]Post, error) {
-	p := &[]Post{}
-	env, err := c.get("/me/posts", p)
+func (c *Client) GetUserPosts() ([]Post, error) {
+	p := []Post{}
+	env, err := c.get("/me/posts", &p)
 	if err != nil {
 		return nil, err
 	}
 
 	var ok bool
-	if p, ok = env.Data.(*[]Post); !ok {
+	newP, ok := env.Data.(*[]Post)
+	if !ok {
 		return nil, fmt.Errorf("Wrong data returned from API.")
 	}
+	p = *newP
 	status := env.Code
 
 	if status != http.StatusOK {


### PR DESCRIPTION
Because slices are pointer types already we don't need to hide them behind
another level of indirection which makes it hard to use the slice
itself.

Some slight workarounds had to be performed because of the odd way in which the value is set, and then set again from the `env` value, but everything appears to be working.