### PR TITLE
Support Markdown endpoint

### DIFF
--- a/formatting.go
+++ b/formatting.go
@@ -1,0 +1,39 @@
+package writeas
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type BodyResponse struct {
+	Body string `json:"body"`
+}
+
+// Markdown takes raw Markdown and renders it into usable HTML. See
+// https://developers.write.as/docs/api/#render-markdown.
+func (c *Client) Markdown(body, collectionURL string) (string, error) {
+	p := &BodyResponse{}
+	data := struct {
+		RawBody       string `json:"raw_body"`
+		CollectionURL string `json:"collection_url,omitempty"`
+	}{
+		RawBody:       body,
+		CollectionURL: collectionURL,
+	}
+
+	env, err := c.post("/markdown", data, p)
+	if err != nil {
+		return "", err
+	}
+
+	var ok bool
+	if p, ok = env.Data.(*BodyResponse); !ok {
+		return "", fmt.Errorf("Wrong data returned from API.")
+	}
+	status := env.Code
+
+	if status != http.StatusOK {
+		return "", fmt.Errorf("Problem getting markdown: %d. %s\n", status, env.ErrorMessage)
+	}
+	return p.Body, nil
+}

--- a/formatting_test.go
+++ b/formatting_test.go
@@ -1,0 +1,23 @@
+package writeas
+
+import (
+	"testing"
+)
+
+func TestMarkdown(t *testing.T) {
+	dwac := NewDevClient()
+
+	in := "This is *formatted* in __Markdown__."
+	out := `<p>This is <em>formatted</em> in <strong>Markdown</strong>.</p>
+`
+
+	res, err := dwac.Markdown(in, "")
+	if err != nil {
+		t.Errorf("Unexpected fetch results: %+v, err: %v\n", res, err)
+	}
+
+	if res != out {
+		t.Errorf(`Got: '%s'
+Expected: '%s'`, res, out)
+	}
+}


### PR DESCRIPTION
This adds support for the [`/api/markdown`](https://developers.write.as/docs/api/#render-markdown) endpoint.