### PR TITLE
Add support for `context.Context`

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -1,13 +1,14 @@
 package writeas
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
 
 // LogIn authenticates a user with Write.as.
 // See https://developers.write.as/docs/api/#authenticate-a-user
-func (c *Client) LogIn(username, pass string) (*AuthUser, error) {
+func (c *Client) LogIn(ctx context.Context, username, pass string) (*AuthUser, error) {
 	u := &AuthUser{}
 	up := struct {
 		Alias string `json:"alias"`
@@ -17,7 +18,7 @@ func (c *Client) LogIn(username, pass string) (*AuthUser, error) {
 		Pass:  pass,
 	}
 
-	env, err := c.post("/auth/login", up, u)
+	env, err := c.post(ctx, "/auth/login", up, u)
 	if err != nil {
 		return nil, err
 	}
@@ -47,8 +48,8 @@ func (c *Client) LogIn(username, pass string) (*AuthUser, error) {
 
 // LogOut logs the current user out, making the Client's current access token
 // invalid.
-func (c *Client) LogOut() error {
-	env, err := c.delete("/auth/me", nil)
+func (c *Client) LogOut(ctx context.Context) error {
+	env, err := c.delete(ctx, "/auth/me", nil)
 	if err != nil {
 		return err
 	}

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,18 +1,22 @@
 package writeas
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestAuthentication(t *testing.T) {
 	dwac := NewDevClient()
+	ctx := context.Background()
 
 	// Log in
-	_, err := dwac.LogIn("demo", "demo")
+	_, err := dwac.LogIn(ctx, "demo", "demo")
 	if err != nil {
 		t.Fatalf("Unable to log in: %v", err)
 	}
 
 	// Log out
-	err = dwac.LogOut()
+	err = dwac.LogOut(ctx)
 	if err != nil {
 		t.Fatalf("Unable to log out: %v", err)
 	}

--- a/author.go
+++ b/author.go
@@ -1,6 +1,7 @@
 package writeas
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -27,13 +28,13 @@ type (
 )
 
 // CreateContributor creates a new contributor on the given organization.
-func (c *Client) CreateContributor(sp *AuthorParams) (*Author, error) {
+func (c *Client) CreateContributor(ctx context.Context, sp *AuthorParams) (*Author, error) {
 	if sp.OrgAlias == "" {
 		return nil, fmt.Errorf("AuthorParams.OrgAlias is required.")
 	}
 
 	a := &Author{}
-	env, err := c.post("/organizations/"+sp.OrgAlias+"/contributors", sp, a)
+	env, err := c.post(ctx, "/organizations/"+sp.OrgAlias+"/contributors", sp, a)
 	if err != nil {
 		return nil, err
 	}

--- a/author_test.go
+++ b/author_test.go
@@ -1,10 +1,14 @@
 package writeas
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestClient_CreateContributor(t *testing.T) {
 	c := NewClientWith(Config{URL: "http://localhost:7777/api"})
-	_, err := c.LogIn("test", "test")
+	ctx := context.Background()
+	_, err := c.LogIn(ctx, "test", "test")
 	if err != nil {
 		t.Fatalf("login: %s", err)
 	}
@@ -24,7 +28,7 @@ func TestClient_CreateContributor(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err = c.CreateContributor(&AuthorParams{
+			_, err = c.CreateContributor(ctx, &AuthorParams{
 				Name:     test.AName,
 				Slug:     test.ASlug,
 				OrgAlias: test.AOrg,

--- a/collection.go
+++ b/collection.go
@@ -1,6 +1,7 @@
 package writeas
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -35,9 +36,9 @@ type (
 // CreateCollection creates a new collection, returning a user-friendly error
 // if one comes up. Requires a Write.as subscription. See
 // https://developers.write.as/docs/api/#create-a-collection
-func (c *Client) CreateCollection(sp *CollectionParams) (*Collection, error) {
+func (c *Client) CreateCollection(ctx context.Context, sp *CollectionParams) (*Collection, error) {
 	p := &Collection{}
-	env, err := c.post("/collections", sp, p)
+	env, err := c.post(ctx, "/collections", sp, p)
 	if err != nil {
 		return nil, err
 	}
@@ -66,9 +67,9 @@ func (c *Client) CreateCollection(sp *CollectionParams) (*Collection, error) {
 // GetCollection retrieves a collection, returning the Collection and any error
 // (in user-friendly form) that occurs. See
 // https://developers.write.as/docs/api/#retrieve-a-collection
-func (c *Client) GetCollection(alias string) (*Collection, error) {
+func (c *Client) GetCollection(ctx context.Context, alias string) (*Collection, error) {
 	coll := &Collection{}
-	env, err := c.get(fmt.Sprintf("/collections/%s", alias), coll)
+	env, err := c.get(ctx, fmt.Sprintf("/collections/%s", alias), coll)
 	if err != nil {
 		return nil, err
 	}
@@ -91,9 +92,9 @@ func (c *Client) GetCollection(alias string) (*Collection, error) {
 // GetCollectionPosts retrieves a collection's posts, returning the Posts
 // and any error (in user-friendly form) that occurs. See
 // https://developers.write.as/docs/api/#retrieve-collection-posts
-func (c *Client) GetCollectionPosts(alias string) (*[]Post, error) {
+func (c *Client) GetCollectionPosts(ctx context.Context, alias string) (*[]Post, error) {
 	coll := &Collection{}
-	env, err := c.get(fmt.Sprintf("/collections/%s/posts", alias), coll)
+	env, err := c.get(ctx, fmt.Sprintf("/collections/%s/posts", alias), coll)
 	if err != nil {
 		return nil, err
 	}
@@ -116,10 +117,10 @@ func (c *Client) GetCollectionPosts(alias string) (*[]Post, error) {
 // GetCollectionPost retrieves a post from a collection
 // and any error (in user-friendly form) that occurs). See
 // https://developers.write.as/docs/api/#retrieve-a-collection-post
-func (c *Client) GetCollectionPost(alias, slug string) (*Post, error) {
+func (c *Client) GetCollectionPost(ctx context.Context, alias, slug string) (*Post, error) {
 	post := Post{}
 
-	env, err := c.get(fmt.Sprintf("/collections/%s/posts/%s", alias, slug), &post)
+	env, err := c.get(ctx, fmt.Sprintf("/collections/%s/posts/%s", alias, slug), &post)
 	if err != nil {
 		return nil, err
 	}
@@ -139,9 +140,9 @@ func (c *Client) GetCollectionPost(alias, slug string) (*Post, error) {
 
 // GetUserCollections retrieves the authenticated user's collections.
 // See https://developers.write.as/docs/api/#retrieve-user-39-s-collections
-func (c *Client) GetUserCollections() (*[]Collection, error) {
+func (c *Client) GetUserCollections(ctx context.Context) (*[]Collection, error) {
 	colls := &[]Collection{}
-	env, err := c.get("/me/collections", colls)
+	env, err := c.get(ctx, "/me/collections", colls)
 	if err != nil {
 		return nil, err
 	}
@@ -165,9 +166,9 @@ func (c *Client) GetUserCollections() (*[]Collection, error) {
 // anonymous.
 //
 // See https://developers.write.as/docs/api/#delete-a-collection.
-func (c *Client) DeleteCollection(alias string) error {
+func (c *Client) DeleteCollection(ctx context.Context, alias string) error {
 	endpoint := "/collections/" + alias
-	env, err := c.delete(endpoint, nil /* data */)
+	env, err := c.delete(ctx, endpoint, nil /* data */)
 	if err != nil {
 		return err
 	}

--- a/collection_test.go
+++ b/collection_test.go
@@ -1,6 +1,7 @@
 package writeas
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -10,7 +11,7 @@ import (
 func TestGetCollection(t *testing.T) {
 	dwac := NewDevClient()
 
-	res, err := dwac.GetCollection("tester")
+	res, err := dwac.GetCollection(context.Background(), "tester")
 	if err != nil {
 		t.Errorf("Unexpected fetch results: %+v, err: %v\n", res, err)
 	}
@@ -22,9 +23,10 @@ func TestGetCollection(t *testing.T) {
 func TestGetCollectionPosts(t *testing.T) {
 	dwac := NewDevClient()
 	posts := []Post{}
+	ctx := context.Background()
 
 	t.Run("Get all posts in collection", func(t *testing.T) {
-		res, err := dwac.GetCollectionPosts("tester")
+		res, err := dwac.GetCollectionPosts(ctx, "tester")
 		if err != nil {
 			t.Errorf("Unexpected fetch results: %+v, err: %v\n", res, err)
 		}
@@ -34,7 +36,7 @@ func TestGetCollectionPosts(t *testing.T) {
 		posts = *res
 	})
 	t.Run("Get one post from collection", func(t *testing.T) {
-		res, err := dwac.GetCollectionPost("tester", posts[0].Slug)
+		res, err := dwac.GetCollectionPost(ctx, "tester", posts[0].Slug)
 		if err != nil {
 			t.Errorf("Unexpected fetch results: %+v, err: %v\n", res, err)
 		}
@@ -51,13 +53,14 @@ func TestGetCollectionPosts(t *testing.T) {
 
 func TestGetUserCollections(t *testing.T) {
 	wac := NewDevClient()
-	_, err := wac.LogIn("demo", "demo")
+	ctx := context.Background()
+	_, err := wac.LogIn(ctx, "demo", "demo")
 	if err != nil {
 		t.Fatalf("Unable to log in: %v", err)
 	}
-	defer wac.LogOut()
+	defer wac.LogOut(ctx)
 
-	res, err := wac.GetUserCollections()
+	res, err := wac.GetUserCollections(ctx)
 	if err != nil {
 		t.Errorf("Unexpected fetch results: %+v, err: %v\n", res, err)
 	} else {
@@ -70,15 +73,16 @@ func TestGetUserCollections(t *testing.T) {
 
 func TestCreateAndDeleteCollection(t *testing.T) {
 	wac := NewDevClient()
-	_, err := wac.LogIn("demo", "demo")
+	ctx := context.Background()
+	_, err := wac.LogIn(ctx, "demo", "demo")
 	if err != nil {
 		t.Fatalf("Unable to log in: %v", err)
 	}
-	defer wac.LogOut()
+	defer wac.LogOut(ctx)
 
 	now := time.Now().Unix()
 	alias := fmt.Sprintf("test-collection-%v", now)
-	c, err := wac.CreateCollection(&CollectionParams{
+	c, err := wac.CreateCollection(ctx, &CollectionParams{
 		Alias: alias,
 		Title: fmt.Sprintf("Test Collection %v", now),
 	})
@@ -86,7 +90,7 @@ func TestCreateAndDeleteCollection(t *testing.T) {
 		t.Fatalf("Unable to create collection %q: %v", alias, err)
 	}
 
-	if err := wac.DeleteCollection(c.Alias); err != nil {
+	if err := wac.DeleteCollection(ctx, c.Alias); err != nil {
 		t.Fatalf("Unable to delete collection %q: %v", alias, err)
 	}
 }
@@ -96,7 +100,7 @@ func TestDeleteCollectionUnauthenticated(t *testing.T) {
 
 	now := time.Now().Unix()
 	alias := fmt.Sprintf("test-collection-does-not-exist-%v", now)
-	err := wac.DeleteCollection(alias)
+	err := wac.DeleteCollection(context.Background(), alias)
 	if err == nil {
 		t.Fatalf("Should not be able to delete collection %q unauthenticated.", alias)
 	}

--- a/formatting.go
+++ b/formatting.go
@@ -1,6 +1,7 @@
 package writeas
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -11,7 +12,7 @@ type BodyResponse struct {
 
 // Markdown takes raw Markdown and renders it into usable HTML. See
 // https://developers.write.as/docs/api/#render-markdown.
-func (c *Client) Markdown(body, collectionURL string) (string, error) {
+func (c *Client) Markdown(ctx context.Context, body, collectionURL string) (string, error) {
 	p := &BodyResponse{}
 	data := struct {
 		RawBody       string `json:"raw_body"`
@@ -21,7 +22,7 @@ func (c *Client) Markdown(body, collectionURL string) (string, error) {
 		CollectionURL: collectionURL,
 	}
 
-	env, err := c.post("/markdown", data, p)
+	env, err := c.post(ctx, "/markdown", data, p)
 	if err != nil {
 		return "", err
 	}

--- a/formatting_test.go
+++ b/formatting_test.go
@@ -1,6 +1,7 @@
 package writeas
 
 import (
+	"context"
 	"testing"
 )
 
@@ -11,7 +12,7 @@ func TestMarkdown(t *testing.T) {
 	out := `<p>This is <em>formatted</em> in <strong>Markdown</strong>.</p>
 `
 
-	res, err := dwac.Markdown(in, "")
+	res, err := dwac.Markdown(context.Background(), in, "")
 	if err != nil {
 		t.Errorf("Unexpected fetch results: %+v, err: %v\n", res, err)
 	}

--- a/post.go
+++ b/post.go
@@ -1,6 +1,7 @@
 package writeas
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -99,9 +100,9 @@ const (
 // GetPost retrieves a published post, returning the Post and any error (in
 // user-friendly form) that occurs. See
 // https://developers.write.as/docs/api/#retrieve-a-post.
-func (c *Client) GetPost(id string) (*Post, error) {
+func (c *Client) GetPost(ctx context.Context, id string) (*Post, error) {
 	p := &Post{}
-	env, err := c.get(fmt.Sprintf("/posts/%s", id), p)
+	env, err := c.get(ctx, fmt.Sprintf("/posts/%s", id), p)
 	if err != nil {
 		return nil, err
 	}
@@ -124,13 +125,13 @@ func (c *Client) GetPost(id string) (*Post, error) {
 
 // CreatePost publishes a new post, returning a user-friendly error if one comes
 // up. See https://developers.write.as/docs/api/#publish-a-post.
-func (c *Client) CreatePost(sp *PostParams) (*Post, error) {
+func (c *Client) CreatePost(ctx context.Context, sp *PostParams) (*Post, error) {
 	p := &Post{}
 	endPre := ""
 	if sp.Collection != "" {
 		endPre = "/collections/" + sp.Collection
 	}
-	env, err := c.post(endPre+"/posts", sp, p)
+	env, err := c.post(ctx, endPre+"/posts", sp, p)
 	if err != nil {
 		return nil, err
 	}
@@ -152,11 +153,11 @@ func (c *Client) CreatePost(sp *PostParams) (*Post, error) {
 
 // UpdatePost updates a published post with the given PostParams. See
 // https://developers.write.as/docs/api/#update-a-post.
-func (c *Client) UpdatePost(id, token string, sp *PostParams) (*Post, error) {
-	return c.updatePost("", id, token, sp)
+func (c *Client) UpdatePost(ctx context.Context, id, token string, sp *PostParams) (*Post, error) {
+	return c.updatePost(ctx, "", id, token, sp)
 }
 
-func (c *Client) updatePost(collection, identifier, token string, sp *PostParams) (*Post, error) {
+func (c *Client) updatePost(ctx context.Context, collection, identifier, token string, sp *PostParams) (*Post, error) {
 	p := &Post{}
 	endpoint := "/posts/" + identifier
 	/*
@@ -167,7 +168,7 @@ func (c *Client) updatePost(collection, identifier, token string, sp *PostParams
 		}
 	*/
 	sp.Token = token
-	env, err := c.put(endpoint, sp, p)
+	env, err := c.put(ctx, endpoint, sp, p)
 	if err != nil {
 		return nil, err
 	}
@@ -191,11 +192,11 @@ func (c *Client) updatePost(collection, identifier, token string, sp *PostParams
 
 // DeletePost permanently deletes a published post. See
 // https://developers.write.as/docs/api/#delete-a-post.
-func (c *Client) DeletePost(id, token string) error {
-	return c.deletePost("", id, token)
+func (c *Client) DeletePost(ctx context.Context, id, token string) error {
+	return c.deletePost(ctx, "", id, token)
 }
 
-func (c *Client) deletePost(collection, identifier, token string) error {
+func (c *Client) deletePost(ctx context.Context, collection, identifier, token string) error {
 	p := map[string]string{}
 	endpoint := "/posts/" + identifier
 	/*
@@ -206,7 +207,7 @@ func (c *Client) deletePost(collection, identifier, token string) error {
 		}
 	*/
 	p["token"] = token
-	env, err := c.delete(endpoint, p)
+	env, err := c.delete(ctx, endpoint, p)
 	if err != nil {
 		return err
 	}
@@ -224,9 +225,9 @@ func (c *Client) deletePost(collection, identifier, token string) error {
 
 // ClaimPosts associates anonymous posts with a user / account.
 // https://developers.write.as/docs/api/#claim-posts.
-func (c *Client) ClaimPosts(sp *[]OwnedPostParams) (*[]ClaimPostResult, error) {
+func (c *Client) ClaimPosts(ctx context.Context, sp *[]OwnedPostParams) (*[]ClaimPostResult, error) {
 	p := &[]ClaimPostResult{}
-	env, err := c.post("/posts/claim", sp, p)
+	env, err := c.post(ctx, "/posts/claim", sp, p)
 	if err != nil {
 		return nil, err
 	}
@@ -251,9 +252,9 @@ func (c *Client) ClaimPosts(sp *[]OwnedPostParams) (*[]ClaimPostResult, error) {
 
 // GetUserPosts retrieves the authenticated user's posts.
 // See https://developers.write.as/docs/api/#retrieve-user-39-s-posts
-func (c *Client) GetUserPosts() (*[]Post, error) {
+func (c *Client) GetUserPosts(ctx context.Context) (*[]Post, error) {
 	p := &[]Post{}
-	env, err := c.get("/me/posts", p)
+	env, err := c.get(ctx, "/me/posts", p)
 	if err != nil {
 		return nil, err
 	}
@@ -275,9 +276,9 @@ func (c *Client) GetUserPosts() (*[]Post, error) {
 
 // PinPost pins a post in the given collection.
 // See https://developers.write.as/docs/api/#pin-a-post-to-a-collection
-func (c *Client) PinPost(alias string, pp *PinnedPostParams) error {
+func (c *Client) PinPost(ctx context.Context, alias string, pp *PinnedPostParams) error {
 	res := &[]BatchPostResult{}
-	env, err := c.post(fmt.Sprintf("/collections/%s/pin", alias), []*PinnedPostParams{pp}, res)
+	env, err := c.post(ctx, fmt.Sprintf("/collections/%s/pin", alias), []*PinnedPostParams{pp}, res)
 	if err != nil {
 		return err
 	}
@@ -310,9 +311,9 @@ func (c *Client) PinPost(alias string, pp *PinnedPostParams) error {
 
 // UnpinPost unpins a post from the given collection.
 // See https://developers.write.as/docs/api/#unpin-a-post-from-a-collection
-func (c *Client) UnpinPost(alias string, pp *PinnedPostParams) error {
+func (c *Client) UnpinPost(ctx context.Context, alias string, pp *PinnedPostParams) error {
 	res := &[]BatchPostResult{}
-	env, err := c.post(fmt.Sprintf("/collections/%s/unpin", alias), []*PinnedPostParams{pp}, res)
+	env, err := c.post(ctx, fmt.Sprintf("/collections/%s/unpin", alias), []*PinnedPostParams{pp}, res)
 	if err != nil {
 		return err
 	}

--- a/post_test.go
+++ b/post_test.go
@@ -1,6 +1,7 @@
 package writeas
 
 import (
+	"context"
 	"fmt"
 	"testing"
 )
@@ -8,8 +9,9 @@ import (
 func TestPostRoundTrip(t *testing.T) {
 	var id, token string
 	dwac := NewClient()
+	ctx := context.Background()
 	t.Run("Create post", func(t *testing.T) {
-		p, err := dwac.CreatePost(&PostParams{
+		p, err := dwac.CreatePost(ctx, &PostParams{
 			Title:   "Title!",
 			Content: "This is a post.",
 			Font:    "sans",
@@ -22,7 +24,7 @@ func TestPostRoundTrip(t *testing.T) {
 		id, token = p.ID, p.Token
 	})
 	t.Run("Get post", func(t *testing.T) {
-		res, err := dwac.GetPost(id)
+		res, err := dwac.GetPost(ctx, id)
 		if err != nil {
 			t.Errorf("Unexpected fetch results: %+v, err: %v\n", res, err)
 		} else {
@@ -33,7 +35,7 @@ func TestPostRoundTrip(t *testing.T) {
 		}
 	})
 	t.Run("Update post", func(t *testing.T) {
-		p, err := dwac.UpdatePost(id, token, &PostParams{
+		p, err := dwac.UpdatePost(ctx, id, token, &PostParams{
 			Content: "Now it's been updated!",
 		})
 		if err != nil {
@@ -43,7 +45,7 @@ func TestPostRoundTrip(t *testing.T) {
 		t.Logf("Post updated: %+v", p)
 	})
 	t.Run("Delete post", func(t *testing.T) {
-		err := dwac.DeletePost(id, token)
+		err := dwac.DeletePost(ctx, id, token)
 		if err != nil {
 			t.Errorf("Post delete failed: %v", err)
 			return
@@ -54,20 +56,21 @@ func TestPostRoundTrip(t *testing.T) {
 
 func TestPinUnPin(t *testing.T) {
 	dwac := NewDevClient()
-	_, err := dwac.LogIn("demo", "demo")
+	ctx := context.Background()
+	_, err := dwac.LogIn(ctx, "demo", "demo")
 	if err != nil {
 		t.Fatalf("Unable to log in: %v", err)
 	}
-	defer dwac.LogOut()
+	defer dwac.LogOut(ctx)
 
 	t.Run("Pin post", func(t *testing.T) {
-		err := dwac.PinPost("tester", &PinnedPostParams{ID: "olx6uk7064heqltf"})
+		err := dwac.PinPost(ctx, "tester", &PinnedPostParams{ID: "olx6uk7064heqltf"})
 		if err != nil {
 			t.Fatalf("Pin failed: %v", err)
 		}
 	})
 	t.Run("Unpin post", func(t *testing.T) {
-		err := dwac.UnpinPost("tester", &PinnedPostParams{ID: "olx6uk7064heqltf"})
+		err := dwac.UnpinPost(ctx, "tester", &PinnedPostParams{ID: "olx6uk7064heqltf"})
 		if err != nil {
 			t.Fatalf("Unpin failed: %v", err)
 		}
@@ -78,7 +81,7 @@ func ExampleClient_CreatePost() {
 	dwac := NewDevClient()
 
 	// Publish a post
-	p, err := dwac.CreatePost(&PostParams{
+	p, err := dwac.CreatePost(context.Background(), &PostParams{
 		Title:   "Title!",
 		Content: "This is a post.",
 		Font:    "sans",

--- a/user.go
+++ b/user.go
@@ -1,6 +1,7 @@
 package writeas
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -39,7 +40,7 @@ type (
 
 // GetMe retrieves the authenticated User's information.
 // See: https://developers.write.as/docs/api/#retrieve-authenticated-user
-func (c *Client) GetMe(verbose bool) (*User, error) {
+func (c *Client) GetMe(ctx context.Context, verbose bool) (*User, error) {
 	if c.Token() == "" {
 		return nil, fmt.Errorf("Unable to get user; no access token given.")
 	}
@@ -48,7 +49,7 @@ func (c *Client) GetMe(verbose bool) (*User, error) {
 	if verbose {
 		params = "?verbose=true"
 	}
-	env, err := c.get("/me"+params, nil)
+	env, err := c.get(ctx, "/me"+params, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This patch seeks to update all methods that make an outgoing request to accept a context as their first argument. This enables the library to carry a deadline and other information across API boundaries.

Fixes #11